### PR TITLE
Version bump to 0.15.2 node_exporter

### DIFF
--- a/node_exporter.yml
+++ b/node_exporter.yml
@@ -2,7 +2,7 @@
 - hosts: all
   remote_user: ubuntu
   vars:
-    node_exporter_version: 0.14.0
+    node_exporter_version: 0.15.2
   tasks:
     - name: test connection
       ping:


### PR DESCRIPTION
Tested to be working correctly with
the prometheus 2.x series.

Just a simple version bump if you still care to update the repository.
It shows up in google search when one searches for "node exporter ansible playbook"
and it works great.

